### PR TITLE
Поправка устаревшего синтаксиса

### DIFF
--- a/provision/roles/keepalived/tasks/configure_rh.yml
+++ b/provision/roles/keepalived/tasks/configure_rh.yml
@@ -5,19 +5,19 @@
   notify: restart keepalived
 
 - name: Updating net.ipv4.ip_nonlocal_bind parameter
-  sudo: yes
+  become: yes
   lineinfile:
     dest: /etc/sysctl.conf
     line: 'net.ipv4.ip_nonlocal_bind=1'
 
 - name: Updating net.ipv4.ip_forward parameter
-  sudo: yes
+  become: yes
   lineinfile:
     dest: /etc/sysctl.conf
     line: 'net.ipv4.ip_forward = 1'
 
 - name: Updating sysctl parameters
-  sudo: yes
+  become: yes
   shell: sysctl -p
 
 - name: Enable keepalived to be started at boot


### PR DESCRIPTION
На новых версиях ansible он ругается на sudo в конфиге при применении playbook.
https://www.middlewareinventory.com/blog/ansible-sudo-ansible-become-example/